### PR TITLE
Prevents empty needle warning

### DIFF
--- a/admin/class-database-proxy.php
+++ b/admin/class-database-proxy.php
@@ -41,7 +41,7 @@ class WPSEO_Database_Proxy {
 
 		// If the table prefix was provided, strip it as it's handled automatically.
 		$table_prefix = $this->get_table_prefix();
-		if ( strpos( $this->table_name, $table_prefix ) === 0 ) {
+		if ( strlen($table_prefix) && strpos( $this->table_name, $table_prefix ) === 0 ) {
 			$this->table_prefix = substr( $this->table_name, strlen( $table_prefix ) );
 		}
 

--- a/admin/class-database-proxy.php
+++ b/admin/class-database-proxy.php
@@ -41,7 +41,7 @@ class WPSEO_Database_Proxy {
 
 		// If the table prefix was provided, strip it as it's handled automatically.
 		$table_prefix = $this->get_table_prefix();
-		if ( strlen($table_prefix) && strpos( $this->table_name, $table_prefix ) === 0 ) {
+		if ( ! empty( $table_prefix ) && strpos( $this->table_name, $table_prefix ) === 0 ) {
 			$this->table_prefix = substr( $this->table_name, strlen( $table_prefix ) );
 		}
 


### PR DESCRIPTION
## Summary
Fixes an empty needle warning if no table prefix is specified.

Fixes #9618